### PR TITLE
feat: add course list, create course and manage course pages with API…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,6 +42,9 @@ import InstructorDashboard from "./features/Dashboard/pages/instructorPages/Inst
 import InstructorDashboardLayout from "./layouts/InstructorDashboardLayout";
 import InstructorAssignmentForm from "./features/Dashboard/components/instructorComponents/InstructorAssignmentForm";
 import InstructorCourseMaterialForm from "./features/Dashboard/components/instructorComponents/InstructorCourseMaterialForm";
+import CourseList from "./features/Dashboard/pages/instructorPages/CourseList";
+import CreateCourse from "./features/Dashboard/pages/instructorPages/CreateCourse";
+import ManageCourse from "./features/Dashboard/pages/instructorPages/ManageCourse";
 //Import Admin Components
 import { AdminLayout } from "./layouts/AdminLayout";
 import Reports from "./features/Dashboard/pages/adminpages/Reports";
@@ -58,7 +61,7 @@ function App() {
     <BrowserRouter>
       <AuthLoginProvider>
         <SearchProvider>
-          <ScrollToTop/>
+          <ScrollToTop />
           <Routes>
             <Route path="/" element={<LandingPage />} />
             <Route path="/login" element={<Login />} />
@@ -114,11 +117,22 @@ function App() {
                   path="assignments"
                   element={<InstructorAssignmentForm />}
                 />
-                <Route path="upload" element={<InstructorCourseMaterialForm courseId="4ea12acd-edcd-4a05-8dc4-67fa0b98fa2d" />} />
+                <Route
+                  path="upload"
+                  element={
+                    <InstructorCourseMaterialForm courseId="4ea12acd-edcd-4a05-8dc4-67fa0b98fa2d" />
+                  }
+                />
                 <Route path="profile" element={<InstructorProfile />} />
                 <Route
                   path="live-sessions"
                   element={<InstructorLiveSession />}
+                />
+                <Route path="courses" element={<CourseList />} />
+                <Route path="courses/create" element={<CreateCourse />} />
+                <Route
+                  path="courses/:courseId/manage"
+                  element={<ManageCourse />}
                 />
               </Route>
             </Route>

--- a/src/features/Dashboard/api/instructorApi.js
+++ b/src/features/Dashboard/api/instructorApi.js
@@ -11,3 +11,39 @@ export const createAssignment = async (courseId, assignmentData) => {
   const response = await api.post(`/assignments/courses/${courseId}/assignments`, assignmentData);
   return response.data;
 };
+
+// Get all courses
+export const getCourses = async () => {
+  const response = await api.get("/courses");
+  return response.data;
+};
+
+// Create Course
+export const createCourse = async (courseData) => {
+  const response = await api.post("/courses", courseData);
+  return response.data;
+};
+
+// Get course details
+export const getCourseDetails = async (courseId) => {
+  const response = await api.get(`/courses/${courseId}`);
+  return response.data;
+};
+
+// Get course lessons
+export const getCourseLessons = async (courseId) => {
+  const response = await api.get(`/courses/${courseId}/lessons`);
+  return response.data;
+};
+
+// Update course (publish / unpublish / edit)
+export const updateCourse = async (courseId, courseData) => {
+  const response = await api.patch(`/courses/${courseId}`, courseData);
+  return response.data;
+};
+
+// Get course assignments
+export const getCourseAssignments = async (courseId) => {
+  const response = await api.get(`/assignments/courses/${courseId}/assignments`);
+  return response.data;
+};

--- a/src/features/Dashboard/components/instructorComponents/InstructorDashMenuBar.jsx
+++ b/src/features/Dashboard/components/instructorComponents/InstructorDashMenuBar.jsx
@@ -27,6 +27,12 @@ export default function InstrucDashMenuBar({ onMenuClick }) {
       path: "dashboard",
     },
     {
+      id: "courses",
+      label: "My Courses",
+      icon: uploadIcon,
+      path: "courses",
+    },
+    {
       id: "upload",
       label: "Upload Courses",
       icon: uploadIcon,

--- a/src/features/Dashboard/hooks/instructorHooks/useGetCourses.js
+++ b/src/features/Dashboard/hooks/instructorHooks/useGetCourses.js
@@ -1,0 +1,27 @@
+import { useState, useEffect } from "react";
+import { getCourses } from "../../api/instructorApi";
+
+const useGetCourses = () => {
+  const [courses, setCourses] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchCourses = async () => {
+      try {
+        const response = await getCourses();
+        setCourses(response.data.courses);
+      } catch (err) {
+        setError(err.response?.data?.message || "Failed to fetch courses");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCourses();
+  }, []);
+
+  return { courses, loading, error };
+};
+
+export default useGetCourses;

--- a/src/features/Dashboard/hooks/instructorHooks/useManageCourse.js
+++ b/src/features/Dashboard/hooks/instructorHooks/useManageCourse.js
@@ -1,0 +1,39 @@
+import { useState, useEffect } from "react";
+import {
+  getCourseDetails,
+  getCourseLessons,
+  getCourseAssignments,
+} from "../../api/instructorApi";
+
+const useManageCourse = (courseId) => {
+  const [course, setCourse] = useState(null);
+  const [lessons, setLessons] = useState([]);
+  const [assignments, setAssignments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [courseRes, lessonsRes, assignmentsRes] = await Promise.all([
+          getCourseDetails(courseId),
+          getCourseLessons(courseId),
+          getCourseAssignments(courseId),
+        ]);
+        setCourse(courseRes.data.course);
+        setLessons(lessonsRes.data.lessons || []);
+        setAssignments(assignmentsRes.data.assignments || []);
+      } catch (err) {
+        setError(err.response?.data?.message || "Failed to fetch course data");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [courseId]);
+
+  return { course, lessons, assignments, loading, error };
+};
+
+export default useManageCourse;

--- a/src/features/Dashboard/pages/instructorPages/CourseList.jsx
+++ b/src/features/Dashboard/pages/instructorPages/CourseList.jsx
@@ -1,0 +1,136 @@
+import { useNavigate } from "react-router-dom";
+import useGetCourses from "../../hooks/instructorHooks/useGetCourses";
+
+function CourseList() {
+  const navigate = useNavigate();
+  const { courses, loading, error } = useGetCourses();
+
+  const defaultThumbnail =
+    "https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=800&q=80";
+
+  const getThumbnailSrc = (thumbnail) => {
+    const normalized = thumbnail && String(thumbnail).trim();
+    if (
+      !normalized ||
+      normalized.toLowerCase() === "null" ||
+      normalized.toLowerCase() === "undefined"
+    ) {
+      return defaultThumbnail;
+    }
+    return normalized;
+  };
+
+  return (
+    <div className="p-8 bg-white min-h-screen">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="text-3xl font-bold text-[#1E3A5F]">My Courses</h1>
+          <p className="text-sm text-[#6B7280] mt-1">
+            Manage and track all your courses
+          </p>
+        </div>
+        <button
+          onClick={() => navigate("/instructor/courses/create")}
+          className="bg-[#0029FD] text-white text-sm font-medium px-6 py-3 rounded-lg hover:bg-blue-800 transition-colors"
+        >
+          + Create Course
+        </button>
+      </div>
+
+      {/* Loading State */}
+      {loading && (
+        <div className="flex items-center justify-center h-64">
+          <p className="text-[#6B7280] text-sm">Loading courses...</p>
+        </div>
+      )}
+
+      {/* Error State */}
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
+          <p className="text-red-600 text-sm">{error}</p>
+        </div>
+      )}
+
+      {/* Empty State */}
+      {!loading && !error && courses.length === 0 && (
+        <div className="flex flex-col items-center justify-center h-64 border-2 border-dashed border-[#E5E7EB] rounded-2xl">
+          <p className="text-lg font-bold text-[#1E3A5F] mb-2">
+            No courses yet
+          </p>
+          <p className="text-sm text-[#6B7280] mb-6">
+            Create your first course to get started
+          </p>
+          <button
+            onClick={() => navigate("/instructor/courses/create")}
+            className="bg-[#0029FD] text-white text-sm font-medium px-6 py-3 rounded-lg hover:bg-blue-800 transition-colors"
+          >
+            + Create Course
+          </button>
+        </div>
+      )}
+
+      {/* Course Cards Grid */}
+      {!loading && !error && courses.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {courses.map((course) => (
+            <div
+              key={course.id}
+              className="border border-[#E5E7EB] rounded-2xl overflow-hidden hover:shadow-lg transition-shadow"
+            >
+              {/* Thumbnail */}
+              <div className="w-full h-40 bg-[#F0F4FF] flex items-center justify-center">
+                <img
+                  src={getThumbnailSrc(course.thumbnail)}
+                  alt={course.title || "Course thumbnail"}
+                  className="w-full h-full object-cover"
+                  onError={(e) => {
+                    e.currentTarget.onerror = null;
+                    e.currentTarget.src = defaultThumbnail;
+                  }}
+                />
+              </div>
+
+              {/* Card Content */}
+              <div className="p-5">
+                <div className="flex items-center justify-between mb-2">
+                  <span
+                    className={`text-xs font-medium px-2 py-1 rounded-full ${course.is_published ? "bg-green-100 text-green-600" : "bg-yellow-100 text-yellow-600"}`}
+                  >
+                    {course.is_published ? "Published" : "Draft"}
+                  </span>
+                  <span className="text-xs text-[#6B7280]">
+                    {course.total_enrollments} enrolled
+                  </span>
+                </div>
+
+                <h3 className="text-base font-bold text-[#1E3A5F] mb-2 line-clamp-1">
+                  {course.title}
+                </h3>
+                <p className="text-xs text-[#6B7280] mb-4 line-clamp-2">
+                  {course.description}
+                </p>
+
+                <div className="flex items-center justify-between">
+                  <p className="text-xs text-[#6B7280]">
+                    By {course.instructor_name}
+                  </p>
+                  <button
+                    onClick={() =>
+                      navigate(`/instructor/courses/${course.id}/manage`)
+                    }
+                    className="bg-[#0029FD] text-white text-xs font-medium px-4 py-2 rounded-lg hover:bg-blue-800 transition-colors"
+                  >
+                    Manage
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default CourseList;

--- a/src/features/Dashboard/pages/instructorPages/CreateCourse.jsx
+++ b/src/features/Dashboard/pages/instructorPages/CreateCourse.jsx
@@ -1,0 +1,243 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { createCourse } from "../../api/instructorApi";
+
+function CreateCourse() {
+  const navigate = useNavigate();
+
+  const [formData, setFormData] = useState({
+    title: "",
+    description: "",
+    thumbnail: "",
+    category: "",
+    level: "beginner",
+  });
+
+  const [tools, setTools] = useState([]);
+  const [toolInput, setToolInput] = useState("");
+  const [errors, setErrors] = useState({});
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleAddTool = (e) => {
+    if (e.key === "Enter" && toolInput.trim()) {
+      e.preventDefault();
+      if (!tools.includes(toolInput.trim())) {
+        setTools([...tools, toolInput.trim()]);
+      }
+      setToolInput("");
+    }
+  };
+
+  const handleRemoveTool = (index) => {
+    setTools(tools.filter((_, i) => i !== index));
+  };
+
+  const validate = () => {
+    const newErrors = {};
+    if (!formData.title.trim()) newErrors.title = "Course title is required";
+    if (!formData.description.trim())
+      newErrors.description = "Description is required";
+    if (!formData.category.trim()) newErrors.category = "Category is required";
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!validate()) return;
+
+    setLoading(true);
+    try {
+      const response = await createCourse({
+        title: formData.title.trim(),
+        description: formData.description.trim(),
+        thumbnail: formData.thumbnail.trim() || null,
+        category: formData.category.trim(),
+        level: formData.level,
+      });
+      navigate("/instructor/courses");
+    } catch (err) {
+      setErrors({
+        submit: err.response?.data?.message || "Failed to create course",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-8 bg-white min-h-screen max-w-3xl">
+      {/* Header */}
+      <button
+        onClick={() => navigate("/instructor/courses")}
+        className="text-[#0029FD] text-sm mb-6 flex items-center gap-1 hover:underline"
+      >
+        ← Back to My Courses
+      </button>
+      <h1 className="text-3xl font-bold text-[#1E3A5F] mb-2">
+        Create New Course
+      </h1>
+      <p className="text-sm text-[#6B7280] mb-10">
+        Fill in the details below to create your course.
+      </p>
+
+      <form onSubmit={handleSubmit}>
+        <div className="flex flex-col gap-6">
+          {/* Course Title */}
+          <div>
+            <label className="block text-sm font-bold text-[#1E3A5F] mb-2">
+              Course Title
+            </label>
+            <input
+              type="text"
+              name="title"
+              value={formData.title}
+              onChange={handleChange}
+              placeholder="e.g. Advanced UI Engineering"
+              className="w-full bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-4 py-3 text-sm text-[#1E3A5F] outline-none"
+            />
+            {errors.title && (
+              <p className="text-red-500 text-xs mt-1">{errors.title}</p>
+            )}
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="block text-sm font-bold text-[#1E3A5F] mb-2">
+              Description
+            </label>
+            <textarea
+              name="description"
+              value={formData.description}
+              onChange={handleChange}
+              placeholder="Describe what students will learn in this course..."
+              className="w-full bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-4 py-3 text-sm text-[#1E3A5F] outline-none h-32 resize-none"
+            />
+            {errors.description && (
+              <p className="text-red-500 text-xs mt-1">{errors.description}</p>
+            )}
+          </div>
+
+          {/* Thumbnail URL */}
+          <div>
+            <label className="block text-sm font-bold text-[#1E3A5F] mb-2">
+              Thumbnail URL
+            </label>
+            <input
+              type="url"
+              name="thumbnail"
+              value={formData.thumbnail}
+              onChange={handleChange}
+              placeholder="https://example.com/image.jpg"
+              className="w-full bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-4 py-3 text-sm text-[#1E3A5F] outline-none"
+            />
+          </div>
+
+          {/* Category and Level side by side */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-bold text-[#1E3A5F] mb-2">
+                Category
+              </label>
+              <input
+                type="text"
+                name="category"
+                value={formData.category}
+                onChange={handleChange}
+                placeholder="e.g. Design, Development"
+                className="w-full bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-4 py-3 text-sm text-[#1E3A5F] outline-none"
+              />
+              {errors.category && (
+                <p className="text-red-500 text-xs mt-1">{errors.category}</p>
+              )}
+            </div>
+            <div>
+              <label className="block text-sm font-bold text-[#1E3A5F] mb-2">
+                Level
+              </label>
+              <select
+                name="level"
+                value={formData.level}
+                onChange={handleChange}
+                className="w-full bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-4 py-3 text-sm text-[#1E3A5F] outline-none"
+              >
+                <option value="beginner">Beginner</option>
+                <option value="intermediate">Intermediate</option>
+                <option value="advanced">Advanced</option>
+              </select>
+            </div>
+          </div>
+
+          {/* Tools & Technologies */}
+          <div>
+            <label className="block text-sm font-bold text-[#1E3A5F] mb-2">
+              Tools & Technologies
+            </label>
+            <div className="w-full bg-[#F9FAFB] border border-[#E5E7EB] rounded-lg px-4 py-3 flex flex-wrap gap-2 min-h-[48px]">
+              {tools.map((tool, index) => (
+                <span
+                  key={index}
+                  className="flex items-center gap-1 bg-[#EEF2FF] text-[#0029FD] text-xs font-medium px-3 py-1 rounded-full"
+                >
+                  {tool}
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveTool(index)}
+                    className="text-[#0029FD] hover:text-red-500 font-bold ml-1"
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+              <input
+                type="text"
+                value={toolInput}
+                onChange={(e) => setToolInput(e.target.value)}
+                onKeyDown={handleAddTool}
+                placeholder={
+                  tools.length === 0
+                    ? "Type a tool and press Enter e.g. VS Code"
+                    : ""
+                }
+                className="flex-1 bg-transparent text-sm text-[#1E3A5F] outline-none min-w-[200px]"
+              />
+            </div>
+            <p className="text-xs text-[#6B7280] mt-1">
+              Press Enter to add each tool
+            </p>
+          </div>
+
+          {errors.submit && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+              <p className="text-red-600 text-sm">{errors.submit}</p>
+            </div>
+          )}
+
+          {/* Buttons */}
+          <div className="flex justify-end gap-4 mt-4">
+            <button
+              type="button"
+              onClick={() => navigate("/instructor/courses")}
+              className="text-[#0029FD] text-sm font-medium px-6 py-3 rounded-lg hover:bg-[#EEF2FF] transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="bg-[#0029FD] disabled:opacity-60 text-white text-sm font-medium px-6 py-3 rounded-lg hover:bg-blue-800 transition-colors"
+            >
+              {loading ? "Creating..." : "Create Course"}
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default CreateCourse;

--- a/src/features/Dashboard/pages/instructorPages/ManageCourse.jsx
+++ b/src/features/Dashboard/pages/instructorPages/ManageCourse.jsx
@@ -1,0 +1,280 @@
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import useManageCourse from "../../hooks/instructorHooks/useManageCourse";
+import { updateCourse } from "../../api/instructorApi";
+
+function ManageCourse() {
+  const { courseId } = useParams();
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState("lessons");
+  const [isUpdatingPublish, setIsUpdatingPublish] = useState(false);
+  const [courseDetails, setCourseDetails] = useState(null);
+  const { course, lessons, assignments, loading, error } =
+    useManageCourse(courseId);
+
+  const defaultThumbnail =
+    "https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=800&q=80";
+
+  useEffect(() => {
+    if (course) {
+      setCourseDetails(course);
+    }
+  }, [course]);
+
+  const handleTogglePublish = async () => {
+    if (!courseDetails) return;
+
+    try {
+      setIsUpdatingPublish(true);
+      const result = await updateCourse(courseId, {
+        is_published: !courseDetails.is_published,
+      });
+      const updatedCourse = result?.data?.course || {
+        ...courseDetails,
+        is_published: !courseDetails.is_published,
+      };
+      setCourseDetails(updatedCourse);
+    } catch (err) {
+      console.error("Failed to update course publish status:", err);
+    } finally {
+      setIsUpdatingPublish(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <p className="text-[#6B7280] text-sm">Loading course...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-8">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <p className="text-red-600 text-sm">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8 bg-white min-h-screen">
+      {/* Back Button */}
+      <button
+        onClick={() => navigate("/instructor/courses")}
+        className="text-[#0029FD] text-sm mb-6 flex items-center gap-1 hover:underline"
+      >
+        ← Back to My Courses
+      </button>
+
+      {/* Course Details */}
+      <div className="flex gap-6 mb-8 p-6 border border-[#E5E7EB] rounded-2xl">
+        {/* Thumbnail */}
+        <div className="w-40 h-28 bg-[#F0F4FF] rounded-xl overflow-hidden shrink-0">
+          <img
+            src={
+              courseDetails?.thumbnail
+                ? courseDetails.thumbnail
+                : defaultThumbnail
+            }
+            alt={courseDetails?.title || "Course thumbnail"}
+            className="w-full h-full object-cover"
+            onError={(e) => {
+              e.currentTarget.onerror = null;
+              e.currentTarget.src = defaultThumbnail;
+            }}
+          />
+        </div>
+        {/* Info */}
+        <div className="flex-1">
+          <div className="flex items-center justify-between mb-2">
+            <h1 className="text-2xl font-bold text-[#1E3A5F]">
+              {courseDetails?.title}
+            </h1>
+            <div className="flex items-center gap-3">
+              <span
+                className={`text-xs font-medium px-3 py-1 rounded-full ${courseDetails?.is_published ? "bg-green-100 text-green-600" : "bg-yellow-100 text-yellow-600"}`}
+              >
+                {courseDetails?.is_published ? "Published" : "Draft"}
+              </span>
+              <button
+                onClick={handleTogglePublish}
+                disabled={isUpdatingPublish}
+                className={`text-xs font-medium px-3 py-1 rounded-lg transition-colors ${courseDetails?.is_published ? "bg-red-50 text-red-500 hover:bg-red-100" : "bg-[#0029FD] text-white hover:bg-blue-800"} ${isUpdatingPublish ? "opacity-60 cursor-not-allowed" : ""}`}
+              >
+                {courseDetails?.is_published ? "Unpublish" : "Publish Course"}
+              </button>
+            </div>
+          </div>
+          <p className="text-sm text-[#6B7280] mb-3">
+            {courseDetails?.description}
+          </p>
+          <p className="text-xs text-[#6B7280]">
+            By {courseDetails?.instructor_name}
+          </p>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-4 border-b border-[#E5E7EB] mb-6">
+        <button
+          onClick={() => setActiveTab("lessons")}
+          className={`pb-3 text-sm font-medium transition-colors ${activeTab === "lessons" ? "text-[#0029FD] border-b-2 border-[#0029FD]" : "text-[#6B7280] hover:text-[#0029FD]"}`}
+        >
+          Lessons ({lessons.length})
+        </button>
+        <button
+          onClick={() => setActiveTab("assignments")}
+          className={`pb-3 text-sm font-medium transition-colors ${activeTab === "assignments" ? "text-[#0029FD] border-b-2 border-[#0029FD]" : "text-[#6B7280] hover:text-[#0029FD]"}`}
+        >
+          Assignments ({assignments.length})
+        </button>
+      </div>
+
+      {/* Lessons Tab */}
+      {activeTab === "lessons" && (
+        <div>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-base font-bold text-[#1E3A5F]">
+              Course Lessons
+            </h2>
+            <button
+              onClick={() =>
+                navigate(`/instructor/courses/${courseId}/add-lesson`)
+              }
+              className="bg-[#0029FD] text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-blue-800 transition-colors"
+            >
+              + Add Lesson
+            </button>
+          </div>
+
+          {lessons.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-40 border-2 border-dashed border-[#E5E7EB] rounded-2xl">
+              <p className="text-sm font-bold text-[#1E3A5F] mb-1">
+                No lessons yet
+              </p>
+              <p className="text-xs text-[#6B7280]">
+                Add your first lesson to get started
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              {lessons.map((lesson, index) => (
+                <div
+                  key={lesson.id}
+                  className="flex items-center justify-between border border-[#E5E7EB] rounded-xl px-5 py-4"
+                >
+                  <div className="flex items-center gap-4">
+                    <span className="w-8 h-8 bg-[#EEF2FF] text-[#0029FD] text-xs font-bold rounded-full flex items-center justify-center">
+                      {index + 1}
+                    </span>
+                    <div>
+                      <p className="text-sm font-medium text-[#1E3A5F]">
+                        {lesson.title}
+                      </p>
+                      <p className="text-xs text-[#6B7280]">
+                        {lesson.content?.substring(0, 60)}...
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() =>
+                        navigate(
+                          `/instructor/courses/${courseId}/lessons/${lesson.id}/edit`,
+                        )
+                      }
+                      className="text-xs text-[#0029FD] border border-[#0029FD] px-3 py-1 rounded-lg hover:bg-[#EEF2FF] transition-colors"
+                    >
+                      Edit
+                    </button>
+                    <button className="text-xs text-red-500 border border-red-200 px-3 py-1 rounded-lg hover:bg-red-50 transition-colors">
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Assignments Tab */}
+      {activeTab === "assignments" && (
+        <div>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-base font-bold text-[#1E3A5F]">
+              Course Assignments
+            </h2>
+            <button
+              onClick={() =>
+                navigate(`/instructor/courses/${courseId}/add-assignment`)
+              }
+              className="bg-[#0029FD] text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-blue-800 transition-colors"
+            >
+              + Add Assignment
+            </button>
+          </div>
+
+          {assignments.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-40 border-2 border-dashed border-[#E5E7EB] rounded-2xl">
+              <p className="text-sm font-bold text-[#1E3A5F] mb-1">
+                No assignments yet
+              </p>
+              <p className="text-xs text-[#6B7280]">
+                Add your first assignment to get started
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              {assignments.map((assignment) => (
+                <div
+                  key={assignment.id}
+                  className="flex items-center justify-between border border-[#E5E7EB] rounded-xl px-5 py-4"
+                >
+                  <div>
+                    <p className="text-sm font-medium text-[#1E3A5F]">
+                      {assignment.title}
+                    </p>
+                    <p className="text-xs text-[#6B7280]">
+                      Due: {new Date(assignment.due_date).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() =>
+                        navigate(
+                          `/instructor/courses/${courseId}/assignments/${assignment.id}/edit`,
+                        )
+                      }
+                      className="text-xs text-[#0029FD] border border-[#0029FD] px-3 py-1 rounded-lg hover:bg-[#EEF2FF] transition-colors"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() =>
+                        navigate(
+                          `/instructor/courses/${courseId}/assignments/${assignment.id}/submissions`,
+                        )
+                      }
+                      className="text-xs text-green-600 border border-green-200 px-3 py-1 rounded-lg hover:bg-green-50 transition-colors"
+                    >
+                      Submissions
+                    </button>
+                    <button className="text-xs text-red-500 border border-red-200 px-3 py-1 rounded-lg hover:bg-red-50 transition-colors">
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ManageCourse;


### PR DESCRIPTION
Title: feat: Instructor Course Management Pages
Description:
Added full course management flow for instructors.
What was done:

Built Course List page — displays all courses as cards with thumbnail, title, description, published/draft status and enrollment count
Built Create Course page — form with title, description, thumbnail URL, category, level and tools/technologies tag input
Built Manage Course page — shows course details with tabs for Lessons and Assignments, with Add/Edit/Delete actions
Added Publish/Unpublish toggle on Manage Course page
Connected all pages to real backend API
Added My Courses to instructor sidebar navigation

API endpoints integrated:

GET /api/courses — fetch all courses
POST /api/courses — create new course
GET /api/courses/{id} — get course details
GET /api/courses/{id}/lessons — get course lessons
GET /api/assignments/courses/{id}/assignments — get course assignments
PATCH /api/courses/{id} — publish/unpublish course